### PR TITLE
NodeInterface

### DIFF
--- a/src/node/nodeInterface.ts
+++ b/src/node/nodeInterface.ts
@@ -1,0 +1,14 @@
+export interface NodeInterface {
+
+    /**
+     * Returns true if the node is attached to another one through his next attribute.
+     * @return {boolean} true if the node as a next node, false otherwise
+     */
+    hasNext(): boolean;
+
+    /**
+     * Returns true if the node is attached to another one through his previous attribute.
+     * @return {boolean} true if the node as a previous node, false otherwise
+     */
+    hasPrevious(): boolean;
+}


### PR DESCRIPTION
Adds an interface for a node with optional next and previous members. Typically used in linked lists.